### PR TITLE
Patch most prop params

### DIFF
--- a/grainlearning/calibrationtoolbox.py
+++ b/grainlearning/calibrationtoolbox.py
@@ -88,10 +88,13 @@ class CalibrationToolbox:
         """
         for self.curr_iter in range(self.num_iter):
             print(f"Calibration step {self.curr_iter}")
-            self.model.run()
-            self.calibration.solve(self.model)
-            self.sigma_list.append( self.model.sigma_max)
+            self.next()
 
+    def next(self):
+        self.model.run()
+        self.calibration.solve(self.model)
+        self.sigma_list.append( self.model.sigma_max)
+    
     @classmethod
     def from_dict(
         cls: Type["CalibrationToolbox"],

--- a/grainlearning/gaussianmixturemodel.py
+++ b/grainlearning/gaussianmixturemodel.py
@@ -89,16 +89,6 @@ class GaussianMixtureModel:
         else:
             self.prior_weight = prior_weight
 
-        self.gmm = BayesianGaussianMixture(
-            n_components=self.max_num_components,
-            weight_concentration_prior=self.prior_weight,
-            covariance_type=self.cov_type,
-            tol=self.tol,
-            max_iter=int(self.max_iter),
-            n_init=self.n_init,
-            random_state=self.seed,
-        )
-
     @classmethod
     # TODO: with this class method, GaussianMixtureModel has only one argument, can we use **kwargs to allow more user input?
     def from_dict(cls: Type["GaussianMixtureModel"], obj: dict):
@@ -153,6 +143,16 @@ class GaussianMixtureModel:
         """
         expanded_normalized_params, max_params = self.expand_weighted_parameters(
             posterior_weight, model
+        )
+
+        self.gmm = BayesianGaussianMixture(
+            n_components=self.max_num_components,
+            weight_concentration_prior=self.prior_weight,
+            covariance_type=self.cov_type,
+            tol=self.tol,
+            max_iter=int(self.max_iter),
+            n_init=self.n_init,
+            random_state=self.seed,
         )
 
         self.gmm.fit(expanded_normalized_params)

--- a/grainlearning/iterativebayesianfilter.py
+++ b/grainlearning/iterativebayesianfilter.py
@@ -113,6 +113,7 @@ class IterativeBayesianFilter:
 
         :param model: Model class
         """
+        model.param_data_prev = model.param_data
         model.param_data = self.sampling.regenerate_params(self.posterior_ibf, model)
 
     def solve(self, model: Type["Model"]):

--- a/grainlearning/models.py
+++ b/grainlearning/models.py
@@ -62,6 +62,9 @@ class Model:
 
     #: Parameter data of shape (num_samples, num_params)
     param_data: np.ndarray
+    
+    #: Parameter data of previous iteration
+    param_data_prev: np.ndarray
 
     #: Number of parameters
     num_params: int
@@ -213,6 +216,7 @@ class Model:
                 )
 
         self.param_data = np.array(param_table, ndmin=2)
+        self.param_data_prev = self.param_data
 
     @classmethod
     def from_dict(cls: Type["Model"], obj: dict) -> Type["Model"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "GrainLearning"
 version = "2.0.0"
 description = ""
 authors = ["Hongyang Cheng <h.cheng@utwente.nl>",
-"Luisa Orozco <l.orozco@esciencecenter.nl>"]
+"Luisa Orozco <l.orozco@esciencecenter.nl>","Retief Lubbe <r.lubbe@utwente.nl>"]
 readme = "README.md"
 keywords = ["DEM", "Bayesian inference"]
 
@@ -30,3 +30,8 @@ prospector = {version = "^1.7.6", extras = ["with_pyroma"]}
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+
+packages = [
+    { include = "grainlearning"}
+]

--- a/tests/integration/test_14sep_lenreg.py
+++ b/tests/integration/test_14sep_lenreg.py
@@ -38,7 +38,7 @@ calibration = CalibrationToolbox.from_dict(
         "model": {
             "param_mins": [0, 0],
             "param_maxs": [1, 10],
-            "num_samples": 14,
+            "num_samples": 13,
             "obs_data": y_obs,
             "ctrl_data": x_obs,
             "callback": run_sim,

--- a/tests/integration/test_14sep_lenreg.py
+++ b/tests/integration/test_14sep_lenreg.py
@@ -53,7 +53,7 @@ calibration = CalibrationToolbox.from_dict(
 calibration.run()
 
 #%%
-print(f'All parameter samples at the last iteration:\n {calibration.model.param_data}')
+print(f'All parameter samples at the last iteration:\n {calibration.model.param_data_prev}')
 
 #%%
 plt.plot( np.arange(calibration.num_iter),calibration.sigma_list)
@@ -62,10 +62,10 @@ plt.plot( np.arange(calibration.num_iter),calibration.sigma_list)
 # print(calibration.sigma_list)
 
 # %%
-most_prob = np.argmax(calibration.calibration.proposal_ibf)
+most_prob = np.argmax(calibration.calibration.posterior_ibf)
 
 # %%
-most_prob_params = calibration.model.param_data[most_prob] 
+most_prob_params = calibration.model.param_data_prev[most_prob] 
 
 print(f'Most probable parameter values: {most_prob_params}')
 # %%
@@ -80,3 +80,5 @@ assert abs(error[1])/5.0 < error_tolerance, f"Model parameters are not correct, 
 
 #2. Checking sigma
 assert calibration.sigma_list[-1] < error_tolerance, "Final sigma is bigger than tolerance."
+
+# %%

--- a/tests/integration/test_linear_regression.py
+++ b/tests/integration/test_linear_regression.py
@@ -1,0 +1,107 @@
+
+#%%
+ 
+import numpy as np
+
+from grainlearning import CalibrationToolbox
+
+import matplotlib.pyplot as plt
+
+
+
+from sklearn.metrics import mean_absolute_error as mae
+
+p1 = 0.2
+
+p2 = 5.0
+x_obs = np.arange(100)
+
+y_obs = p1* x_obs + p2
+
+y_obs_w_noise = y_obs + np.random.rand(100) * 2.5
+
+
+def run_sim(model):
+    data = []
+    for params in model.param_data:
+        y_sim = params[0] * model.ctrl_data + params[1]
+        data.append(np.array(y_sim, ndmin=2))
+    
+    model.sim_data = np.array(data)
+    
+    plt.figure()
+    plt.plot(model.ctrl_data, model.obs_data, ls="", marker=".", label="Observation")
+    for i,y_sims in enumerate(model.sim_data):
+       params =  model.param_data[i]
+       print(i,params)
+       plt.plot(model.ctrl_data[0], y_sims[0], label="Simulation")
+       plt.text(model.ctrl_data[0][-1], y_sims[0][-1], "{}".format(i,params[0],params[1]), bbox=dict(facecolor='red', alpha=0.5))
+    plt.show()
+
+
+def test_step_forward():
+    calibration = CalibrationToolbox.from_dict(
+        {
+            "num_iter": 8,
+            "model": {
+                "param_mins": [0, 0],
+                "param_maxs": [1, 10],
+                "num_samples": 13,
+                "obs_data": y_obs,
+                "ctrl_data": x_obs,
+                "callback": run_sim,
+            },
+            "calibration": {
+                "inference": {"ess_target": 0.3},
+                "sampling": {"max_num_components": 1},
+            }
+        }
+    )
+
+    calibration.next()
+    
+    
+    most_prob = np.argmax(calibration.calibration.posterior_ibf)
+
+
+    # most_prob_params = calibration.model.param_data[most_prob] 
+
+    least_err = np.argmin([mae(calibration.model.sim_data[sid,0,:],y_obs) for sid in range(calibration.model.num_samples)])
+    
+    assert most_prob == least_err, f"most probable does not have the least MAE {most_prob=} {least_err=}"
+
+
+
+test_step_forward()
+# #%%
+# print(f'All parameter samples at the last iteration:\n {calibration.model.param_data_prev}')
+
+# #%%
+# plt.plot( np.arange(calibration.num_iter),calibration.sigma_list)
+# #%%
+# # calibration.sigma_list,len(calibration.sigma_list),calibration.num_iter
+# # print(calibration.sigma_list)
+
+# # %%
+# most_prob = np.argmax(calibration.calibration.posterior_ibf)
+
+# # %%
+# most_prob_params = calibration.model.param_data_prev[most_prob] 
+
+# print(f'Most probable parameter values: {most_prob_params}')
+# # %%
+
+# #tests
+# error_tolerance = 0.01
+
+# #1. Testing values of parameters
+# error = most_prob_params - [0.2,5.0]
+# assert abs(error[0])/0.2 < error_tolerance, f"Model parameters are not correct, expected 0.2 but got {most_prob_params[0]}"
+# assert abs(error[1])/5.0 < error_tolerance, f"Model parameters are not correct, expected 5.0 but got {most_prob_params[1]}"
+
+# #2. Checking sigma
+# assert calibration.sigma_list[-1] < error_tolerance, "Final sigma is bigger than tolerance."
+
+# # %%
+
+# %%

--- a/tests/unit/test_guassianmixturemodel.py
+++ b/tests/unit/test_guassianmixturemodel.py
@@ -15,9 +15,6 @@ def test_init():
 
     gmm_dct_dct = gmm_dct.__dict__
 
-    gmm_cls_dct.pop("gmm")
-
-    gmm_dct_dct.pop("gmm")
 
     np.testing.assert_equal(gmm_dct.__dict__, gmm_cls.__dict__)
 

--- a/tests/unit/test_guassianmixturemodel.py
+++ b/tests/unit/test_guassianmixturemodel.py
@@ -11,11 +11,6 @@ def test_init():
 
     gmm_dct = GaussianMixtureModel.from_dict({"max_num_components": 5})
 
-    gmm_cls_dct = gmm_cls.__dict__
-
-    gmm_dct_dct = gmm_dct.__dict__
-
-
     np.testing.assert_equal(gmm_dct.__dict__, gmm_cls.__dict__)
 
     assert gmm_cls.prior_weight == 1.0 / 5


### PR DESCRIPTION
Fixed three issues that might cause problems:

1. Reinitialized GMM. It seems like GMM stores the state between calibration iterations. Refitting does not clear the state.
2. Added param_data_prev, we find the most probable params with at the previous calibration iteration
3. Fixed type posterior_ibf instead of proposal_ibf