### PR TITLE
Changes to fix Readthedocs poetry error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,6 @@ build:
       # (We are in a virtual environement anyway)
       - poetry config virtualenvs.create false
     post_install:
+      # commented out because poetry in readthedocs environement was not able to find right packages otherwise
       # - poetry lock --no-update
       - poetry install -E docs -E rnn

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,12 @@ build:
   tools:
     python: "3.9"
   jobs:
-    post_install:
+    post_create_environment:
+      # install poetry https://docs.readthedocs.io/en/stable/build-customization.html#id11
       - pip install poetry
+      # Tell poetry to not use a virtual environment 
+      # (We are in a virtual environement anyway)
       - poetry config virtualenvs.create false
+    post_install:
       - poetry lock --no-update
       - poetry install -E docs -E rnn

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.9"
   jobs:
     post_install:
-      - pip install poetry==1.2.0b1
+      - pip install poetry
       - poetry config virtualenvs.create false
       - poetry lock --no-update
       - poetry install -E docs -E rnn

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,5 @@ build:
       # (We are in a virtual environement anyway)
       - poetry config virtualenvs.create false
     post_install:
-      - poetry lock --no-update
+      # - poetry lock --no-update
       - poetry install -E docs -E rnn


### PR DESCRIPTION
The workflow in readthedocs was not passing.
I found that the solution was on using the lock file form poetry, this means I removed the command: `poetry lock --no-update`. 
Now the documentation is passing, so we can merge this changes to main.