### PR TITLE
Python versions and warning for windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Browse to the [GrainLearning documentation](https://grainlearning.readthedocs.io
 
 1. Clone the repository: `git clone https://github.com/GrainLearning/grainLearning.git`
 1. Go to the source code directory: `cd grainLearning`
-1. Activate the virtual environment: `conda create --name grainlearning python=3.8 && conda activate grainlearning`
+1. Activate the virtual environment: `conda create --name grainlearning python=3.11 && conda activate grainlearning`
 1. Install GrainLearning and its dependencies: `pip install .`
 
 __Developers__ please refer to [README.dev.md](README.dev.md).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,8 +1,8 @@
 Installation
 ============
 
-GrainLearning can be installed with poetry and pip, on Windows, Mac, and Linux OS, with a Python version higher than 3.8.
-We have tested GrainLearning with Python versions 3.8, 3.9, and 3.10.
+GrainLearning can be installed with poetry and pip, on Windows, Mac, and Linux OS, with a Python version higher than 3.9.
+We have tested GrainLearning with Python versions 3.9, 3.10, 3.11, 3.12.
 
 Package management and dependencies
 -----------------------------------
@@ -30,6 +30,9 @@ First, install poetry following `these instructions <https://python-poetry.org/d
    # You are done. Try any examples in the ./tutorials directory
    poetry run python <example.py>
 
+
+.. note:: In windows systems, if you experience problems installing `tensorflow` using poetry, try using pip.
+
 Install using pip
 `````````````````
 
@@ -41,7 +44,7 @@ Install using pip
 
    # We recommend working in a virtual environment using conda or any other python environment manager.
    # for example, with anaconda
-   conda create --name grainlearning python=3.8
+   conda create --name grainlearning python=3.11
    conda activate grainlearning
 
    # Install GrainLearning and its dependencies 
@@ -106,7 +109,7 @@ Online
 You can check the online documentation `here <https://grainlearning.readthedocs.io/en/latest/>`_.
 
 Build the documentation locally
-```````````````````````
+```````````````````````````````
 
 .. code-block:: bash
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ pytest-cov = {version = "^2.12.1", optional = true}
 prospector = {version = "^1.7.6", optional = true, extras = ["with_pyroma"]}
 pyroma = {version = "^4.0", optional = true}
 h5py = {version = "^3.7.0", optional = true}
-wandb = {version = "^0.13.4", optional = true}
+wandb = {version = "^0.15.10", optional = true}
 tensorflow = {version = "^2.10.0", optional = true}
 ipykernel = {version = "*", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<=3.12"
 numpy = "^1.23.2"
 scipy = "^1.9.1"
 scikit-learn = "^1.1.3"
@@ -27,14 +27,14 @@ seaborn = '^0.12.2'
 Sphinx = {version = "^5.1.1", optional = true}
 sphinx-autodoc-typehints = {version = "^1.19.2", optional = true}
 sphinx-mdinclude = {version = "*", optional = true}
-sphinx-rtd-theme = {version=">=1.1.1", optional = true}
+sphinx-rtd-theme = {version = ">=1.1.1", optional = true}
 pytest = {version = "^6.2.4", optional = true}
 pytest-cov = {version = "^2.12.1", optional = true}
 prospector = {version = "^1.7.6", optional = true, extras = ["with_pyroma"]}
 pyroma = {version = "^4.0", optional = true}
-h5py = {version ="^3.7.0", optional = true}
-wandb = {version ="^0.13.4", optional = true}
-tensorflow = {version ="^2.10.0", optional = true}
+h5py = {version = "^3.7.0", optional = true}
+wandb = {version = "^0.13.4", optional = true}
+tensorflow = {version = "^2.10.0", optional = true}
 ipykernel = {version = "*", optional = true}
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.12"
+python = ">=3.9,<3.12"
 numpy = "^1.23.2"
 scipy = "^1.9.1"
 scikit-learn = "^1.1.3"


### PR DESCRIPTION
## Context
We have been seeing for a while that the build action on windows keeps on failing. I have narrowed down that the issue is with a dependency of `tensorflow: tensorflow-io-gcs-filesystem` for which the wheels for windows have been somehow forgotten or not published anymore (https://github.com/tensorflow/io/issues/1815 and [reports via other channels](https://discuss.tensorflow.org/t/tensorflow-io-gcs-filesystem-with-windows/18849/4)).
Furthermore, the workflow for 3.12 fails due to a setting on `pyproject.toml`.

## Changes made
In this PR:
- Update the version of python supported: 3.9-3.12 in several files (`pyproject.toml`, documentation).
- Add a note in the documentation recommending to the users to install using pip if poetry cannot resolve the tensorflow dependency.
- Add instructions to generate the documentation on windows without using poetry and on the command line.
- Modify spaces around `=` in `pyproject.toml` for consistency and readability.

This PR closes #65 