### PR TITLE
Add note to windows installation via poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Browse to the [GrainLearning documentation](https://grainlearning.readthedocs.io
 
 1. Clone the repository: `git clone https://github.com/GrainLearning/grainLearning.git`
 1. Go to the source code directory: `cd grainLearning`
-1. Activate the virtual environment: `conda create --name grainlearning python=3.8 && conda activate grainlearning`
+1. Activate the virtual environment: `conda create --name grainlearning python=3.11 && conda activate grainlearning`
 1. Install GrainLearning and its dependencies: `pip install .`
 
 __Developers__ please refer to [README.dev.md](README.dev.md).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,8 +1,8 @@
 Installation
 ============
 
-GrainLearning can be installed with poetry and pip, on Windows, Mac, and Linux OS, with a Python version higher than 3.8.
-We have tested GrainLearning with Python versions 3.8, 3.9, and 3.10.
+GrainLearning can be installed with poetry and pip, on Windows, Mac, and Linux OS, with a Python version higher than 3.9.
+We have tested GrainLearning with Python versions 3.9, 3.10, and 3.11.
 
 Package management and dependencies
 -----------------------------------
@@ -29,6 +29,8 @@ First, install poetry following `these instructions <https://python-poetry.org/d
 
    # You are done. Try any examples in the ./tutorials directory
    poetry run python <example.py>
+
+.. note:: In windows systems, if you experience problems installing `tensorflow` using poetry, try using pip.
 
 Install using pip
 `````````````````
@@ -106,7 +108,7 @@ Online
 You can check the online documentation `here <https://grainlearning.readthedocs.io/en/latest/>`_.
 
 Build the documentation locally
-```````````````````````
+```````````````````````````````
 
 .. code-block:: bash
   


### PR DESCRIPTION
## Context
We have been seeing for a while that the build action on windows keeps on failing. I have narrowed down that the issue is with a dependency of tensorflow: tensorflow-io-gcs-filesystem for which the wheels for windows have been somehow forgotten or not published anymore (https://github.com/tensorflow/io/issues/1815 and [reports via other channels](https://discuss.tensorflow.org/t/tensorflow-io-gcs-filesystem-with-windows/18849/4)).

## Changes in this PR
Add a note in the documentation recommending to the users to install using pip if poetry cannot resolve the tensorflow dependency.