### PR TITLE
Update readthedocs script

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,10 +8,5 @@ build:
     post_create_environment:
       # install poetry https://docs.readthedocs.io/en/stable/build-customization.html#id11
       - pip install poetry
-      # Tell poetry to not use a virtual environment 
-      # (We are in a virtual environement anyway)
-      - poetry config virtualenvs.create false
     post_install:
-      # commented out because poetry in readthedocs environement was not able to find right packages otherwise
-      # - poetry lock --no-update
       - poetry install -E docs -E rnn

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,4 +9,7 @@ build:
       # install poetry https://docs.readthedocs.io/en/stable/build-customization.html#id11
       - pip install poetry
     post_install:
-      - poetry install -E docs -E rnn
+      # Install dependencies with 'docs' dependency group
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install -E docs -E rnn

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | code repository              | [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/GrainLearning/grainlearning) |
 | license                      |  [![github license badge](https://img.shields.io/github/license/GrainLearning/grainlearning)](https://github.com/GrainLearning/grainlearning)|
 | community registry           |  [![RSD](https://img.shields.io/badge/rsd-grainlearning-00a3e3.svg)](https://research-software-directory.org/projects/granular-materials) [![workflow pypi badge](https://img.shields.io/pypi/v/grainlearning.svg?colorB=blue)](https://pypi.python.org/project/grainlearning/)|
-| citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7123966.svg)](https://doi.org/10.5281/zenodo.7123966)|
+| citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7123965.svg)](https://doi.org/10.5281/zenodo.7123965)|
 | Best practices checklist     | [![workflow cii badge](https://bestpractices.coreinfrastructure.org/projects/6533/badge)](https://bestpractices.coreinfrastructure.org/projects/6533)|
 | howfairis                    | [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)|
 | Documentation                | [![Documentation Status](https://readthedocs.org/projects/grainlearning/badge/?version=latest)](https://grainlearning.readthedocs.io/en/latest/?badge=latest)|


### PR DESCRIPTION
## Context
Docs were failing due to a change in readthedocs handling of virtual environments with poetry: see issues [11149](https://github.com/readthedocs/readthedocs.org/issues/11149) and [11150](https://github.com/readthedocs/readthedocs.org/issues/11150), as well as [PR solving them](https://github.com/readthedocs/readthedocs.org/pull/11152/).

With these changes, readthedocs documentation, and specifically [instruction to use poetry backend](https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry) was updated.

## Changes
In this PR, I updated `.readthedocs.yaml` accordingly to the new instructions.

## Tests
I've tested the deployment of this branch `docs_pip` in readthedocs: [succesfull build](https://readthedocs.org/projects/grainlearning/builds/24124235/) | [docs](https://grainlearning.readthedocs.io/en/docs_pip/)